### PR TITLE
Extend debug info

### DIFF
--- a/src/components/DebugInfo.js
+++ b/src/components/DebugInfo.js
@@ -1,16 +1,38 @@
 Crafty.c("DebugInfo", {
   init() {
+    let frameTime = 0;
+    let renderTime = 0;
+    let slowestFrameTime = 0;
+    let slowestRenderTime = 0;
+
+    let slowFrameCount = 0;
+    let slowRenderCount = 0;
+
     this.requires("2D, Text, Tween, Delay, UILayerDOM");
     this.attr({ x: 0, y: 20, w: Crafty.viewport.width - 30, z: 1 })
       .textAlign("right")
       .textColor("#FFFFFF")
       .textFont({
-        size: "14px",
+        size: "6px",
         family: "Press Start 2P"
       });
+    this.bind("MeasureFrameTime", ms => {
+      if (ms > slowestFrameTime) slowestFrameTime = ms;
+      if (ms > 5) slowFrameCount++;
+      frameTime = ms;
+    });
+    this.bind("MeasureRenderTime", ms => {
+      if (ms > slowestRenderTime) slowestRenderTime = ms;
+      if (ms > 5) slowRenderCount++;
+      renderTime = ms;
+    });
     this.bind("EnterFrame", fd => {
       this.text(
         `T: ${Math.round(Game.gameTime / 1000)}s ` +
+          `RT: ${renderTime}ms ` +
+          `SRT: ${slowestRenderTime}ms (${slowRenderCount}) ` +
+          `FT: ${frameTime}ms ` +
+          `SFT: ${slowestFrameTime}ms (${slowFrameCount}) ` +
           `E: ${Crafty("*").length} ` +
           `FPS: ${Math.round(1000 / fd.dt)}`
       );


### PR DESCRIPTION
It now shows:

<img width="585" alt="screen shot 2018-01-09 at 20 34 58" src="https://user-images.githubusercontent.com/23627/34739450-9cee1022-f57c-11e7-8b19-4bfe43165bb1.png">
  
- T:  In game time
- RT: current render time
- SRT: slowest render time (amount of render times above 5ms)
- FT: current frame time
- SFT: slowest frame time (amount of frame times above 5ms)
- E: Amount of entities active
- FPS: Frames per second